### PR TITLE
Removing unsupported variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -210,7 +210,6 @@ variable "integration_default_namespace_rules" {
     sagemakertrainingjobs          = false
     sagemakertransformjobs         = false
     sagemakerworkteam              = false
-    service_quotas                 = false
     ses                            = false
     shield                         = false
     sns                            = false


### PR DESCRIPTION
As far as I can tell there is no replacement for service_quotas, the unsupported variable I've removed, in Datadog at this time and using this module's resource. That being said, the entire datadog_integration_aws resource that this module relies on is now deprecated in favor of [datadog_integration_aws_account](https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/integration_aws_account), which may have a replacement.

This module is going to need to be refactored to use the new resource at some point as we're only going to encounter more issues down the road. This gets us in a working state for now.