### PR TITLE
Fix for time_rotating bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ module "datadog" {
 | [terraform_data.external_id](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [time_rotating.access_key](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/rotating) | resource |
 | [time_sleep.wait_datadog_forwarder](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [time_static.access_key](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/static) | resource |
 | [archive_file.rds_enhanced_monitoring](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/main.tf
+++ b/main.tf
@@ -111,6 +111,12 @@ resource "time_rotating" "access_key" {
   rotation_days = var.access_key_rotation_days
 }
 
+resource "time_static" "access_key" {
+  count = var.access_method == "user" ? 1 : 0
+
+  rfc3339 = time_rotating.access_key[0].rfc3339
+}
+
 resource "aws_iam_access_key" "datadog" {
   count = var.access_method == "user" ? 1 : 0
 
@@ -118,7 +124,7 @@ resource "aws_iam_access_key" "datadog" {
 
   lifecycle {
     create_before_destroy = true
-    replace_triggered_by  = [time_rotating.access_key[0]]
+    replace_triggered_by  = [time_static.access_key[0]]
   }
 }
 


### PR DESCRIPTION
Addresses [terraform-provider-time issue #118](https://github.com/hashicorp/terraform-provider-time/issues/118)

Uses time_static to store the rotation value of time_rotating in state.